### PR TITLE
Small improvements to schema and querying

### DIFF
--- a/drizzle/0005_typical_spot.sql
+++ b/drizzle/0005_typical_spot.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "chapters" DROP COLUMN "story_so_far";

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,215 @@
+{
+  "id": "ea3e1a1e-f502-42d6-8b50-eced562a932f",
+  "prevId": "9d69e6e3-cc0e-4297-83fc-bcb50971a89c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.adventure_types": {
+      "name": "adventure_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.adventures": {
+      "name": "adventures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adventure_type_id": {
+          "name": "adventure_type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "adventures_adventure_type_id_adventure_types_id_fk": {
+          "name": "adventures_adventure_type_id_adventure_types_id_fk",
+          "tableFrom": "adventures",
+          "tableTo": "adventure_types",
+          "columnsFrom": [
+            "adventure_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapter_choices": {
+      "name": "chapter_choices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen": {
+          "name": "chosen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "chapter_id": {
+          "name": "chapter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chapter_choices_chapter_id_chapters_id_fk": {
+          "name": "chapter_choices_chapter_id_chapters_id_fk",
+          "tableFrom": "chapter_choices",
+          "tableTo": "chapters",
+          "columnsFrom": [
+            "chapter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chapters": {
+      "name": "chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "number": {
+          "name": "number",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "narrative": {
+          "name": "narrative",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adventure_id": {
+          "name": "adventure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chapters_adventure_id_adventures_id_fk": {
+          "name": "chapters_adventure_id_adventures_id_fk",
+          "tableFrom": "chapters",
+          "tableTo": "adventures",
+          "columnsFrom": [
+            "adventure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1753724105994,
       "tag": "0004_luxuriant_peter_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1759346143955,
+      "tag": "0005_typical_spot",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -19,7 +19,6 @@ export const chaptersTable = pgTable('chapters', {
   id: uuid().primaryKey().defaultRandom(),
   number: smallint().notNull(),
   narrative: text().notNull(),
-  story_so_far: text().notNull(),
   created: timestamp().notNull(),
   adventure_id: uuid()
     .notNull()

--- a/src/plugins/chaptersRepository.ts
+++ b/src/plugins/chaptersRepository.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
-import { asc, desc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, or, isNull } from 'drizzle-orm';
 import fastifyPlugin from 'fastify-plugin';
-import { chaptersTable } from '@/db/schema';
+import { chaptersTable, chapterChoicesTable } from '@/db/schema';
 
 declare module 'fastify' {
   export interface FastifyInstance {
@@ -10,6 +10,8 @@ declare module 'fastify' {
 }
 
 type Chapter = typeof chaptersTable.$inferSelect;
+type ChapterChoice = typeof chapterChoicesTable.$inferSelect;
+type ChapterWithChoices = { chapters: Chapter; chapter_choices: ChapterChoice | null };
 
 interface ChapterCreate {
   adventureId: string;
@@ -25,6 +27,23 @@ const createRepository = (fastify: FastifyInstance) => {
       const results = await db
         .select()
         .from(chaptersTable)
+        .where(eq(chaptersTable.adventure_id, adventureId))
+        .orderBy(asc(chaptersTable.number));
+
+      return results;
+    },
+
+    async getByAdventureIdOrderedWithChoices(adventureId: string): Promise<ChapterWithChoices[]> {
+      const results = await db
+        .select()
+        .from(chaptersTable)
+        .leftJoin(
+          chapterChoicesTable,
+          and(
+            eq(chaptersTable.id, chapterChoicesTable.chapter_id),
+            eq(chapterChoicesTable.chosen, true),
+          ),
+        )
         .where(eq(chaptersTable.adventure_id, adventureId))
         .orderBy(asc(chaptersTable.number));
 

--- a/src/plugins/chaptersRepository.ts
+++ b/src/plugins/chaptersRepository.ts
@@ -15,7 +15,6 @@ interface ChapterCreate {
   adventureId: string;
   number: number;
   narrative: string;
-  storySoFar: string;
 }
 
 const createRepository = (fastify: FastifyInstance) => {
@@ -52,7 +51,6 @@ const createRepository = (fastify: FastifyInstance) => {
         adventure_id: newChapterData.adventureId,
         number: newChapterData.number,
         narrative: newChapterData.narrative,
-        story_so_far: newChapterData.storySoFar,
         created: new Date(),
       };
 

--- a/src/routes/adventures/index.ts
+++ b/src/routes/adventures/index.ts
@@ -193,7 +193,6 @@ const plugin: FastifyPluginAsync<AdventuresRoutesOptions> = async (
         adventureId: adventure.id,
         number: chapters.length + 1,
         narrative: generatedNarrative,
-        storySoFar: 'a choice has presented itself',
       };
 
       // Persist changes in DB

--- a/src/routes/adventures/index.ts
+++ b/src/routes/adventures/index.ts
@@ -187,25 +187,6 @@ const plugin: FastifyPluginAsync<AdventuresRoutesOptions> = async (
       console.log('gen result', generatedResult);
 
       const generatedNarrative = generatedResult.content.narrative;
-      // For use in place of actual chapter generation
-      const placeholderInitialChapter = {
-        adventureId: adventure.id,
-        number: 1,
-        narrative: generatedNarrative,
-        storySoFar: 'a choice has presented itself',
-      };
-      const placeholderFollowupChapter = {
-        adventureId: adventure.id,
-        number: 0,
-        narrative: generatedNarrative,
-        storySoFar: 'another choice has presented itself',
-      };
-      // For use in place of actual choice generation
-      const placeholderChoices = [
-        { action: 'first action' },
-        { action: 'second action' },
-        { action: 'third action' },
-      ];
 
       // If no previous chapters, begin the first, otherwise, carry with the next
       const nextChapterData = {
@@ -216,14 +197,16 @@ const plugin: FastifyPluginAsync<AdventuresRoutesOptions> = async (
       };
 
       // Persist changes in DB
-      if (latestChapter && choice) {
-        await chapterChoicesRepository.updateByIds(choice, latestChapter.id, { chosen: true });
-      }
       const nextChapter = await chaptersRepository.create(nextChapterData);
       const generatedChoices = generatedResult.content.options.map((opt) => ({
         chapterId: nextChapter.id,
         action: opt.action,
       }));
+
+      if (latestChapter && choice) {
+        await chapterChoicesRepository.updateByIds(choice, latestChapter.id, { chosen: true });
+      }
+
       let nextChoices: ChapterChoice[] = [];
       if (generatedChoices.length > 0) {
         nextChoices = await chapterChoicesRepository.createMultiple(generatedChoices);

--- a/tests/TestDbClient.ts
+++ b/tests/TestDbClient.ts
@@ -33,15 +33,10 @@ export default class TestDbClient {
     return result.rows[0];
   }
 
-  async createChapter(
-    adventureId: string,
-    chapterNumber: number,
-    narrative: string,
-    storySoFar: string,
-  ) {
+  async createChapter(adventureId: string, chapterNumber: number, narrative: string) {
     const text =
-      'INSERT INTO chapters (adventure_id, number, narrative, story_so_far, created) VALUES ($1, $2, $3, $4, $5) RETURNING *';
-    const values = [adventureId, chapterNumber, narrative, storySoFar, new Date()];
+      'INSERT INTO chapters (adventure_id, number, narrative, created) VALUES ($1, $2, $3, $4) RETURNING *';
+    const values = [adventureId, chapterNumber, narrative, new Date()];
     const result = await this.query(text, values);
 
     return result.rows[0];

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -195,12 +195,7 @@ describe('Adventures Gameplay Injection Tests', () => {
     const adventureType = adventureTypes[0];
 
     const adventure = await db.createAdventure(adventureType.id, true);
-    const chapter = await db.createChapter(
-      adventure.id,
-      1,
-      'the initial chapter goes here',
-      'an epic adventure has ensued',
-    );
+    const chapter = await db.createChapter(adventure.id, 1, 'the initial chapter goes here');
 
     const response = await app.inject({
       method: 'POST',
@@ -221,12 +216,7 @@ describe('Adventures Gameplay Injection Tests', () => {
     const adventureType = adventureTypes[0];
 
     const adventure = await db.createAdventure(adventureType.id, true);
-    const chapter = await db.createChapter(
-      adventure.id,
-      1,
-      'the initial chapter goes here',
-      'an epic adventure has ensued',
-    );
+    const chapter = await db.createChapter(adventure.id, 1, 'the initial chapter goes here');
 
     const response = await app.inject({
       method: 'POST',
@@ -249,12 +239,7 @@ describe('Adventures Gameplay Injection Tests', () => {
     const adventureType = adventureTypes[0];
 
     const adventure = await db.createAdventure(adventureType.id, true);
-    const chapter = await db.createChapter(
-      adventure.id,
-      1,
-      'the initial chapter goes here',
-      'an epic adventure has ensued',
-    );
+    const chapter = await db.createChapter(adventure.id, 1, 'the initial chapter goes here');
     const chapterChoice = await db.createChapterChoice(chapter.id, 'a brave action', false);
 
     const response = await app.inject({
@@ -300,15 +285,9 @@ describe('Adventures Gameplay Injection Tests', () => {
       adventure.id,
       1,
       'this is the first choice chapter',
-      'an epic adventure has ensued',
     );
     await db.createChapterChoice(firstChapter.id, 'a brave action', true);
-    const chapter = await db.createChapter(
-      adventure.id,
-      2,
-      'this is the final choice chapter',
-      'an epic adventure has ensued',
-    );
+    const chapter = await db.createChapter(adventure.id, 2, 'this is the final choice chapter');
     const chapterChoice = await db.createChapterChoice(chapter.id, 'a brave action', false);
 
     const response = await app.inject({

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -326,7 +326,7 @@ describe('Adventures Gameplay Injection Tests', () => {
     expect(data).toHaveProperty('narrative');
     expect(data).toHaveProperty('choices');
     expect(data.chapterNumber).toBe(3);
-    expect(data.narrative).toBe('a new chapter goes here!');
+    expect(data.narrative).toBe('this is how the story ends!');
     expect(data.choices.length).toBe(0);
 
     // Check that choice is now flagged as chosen


### PR DESCRIPTION
- Drop the `story_so_far` column. Better to send the raw story flow rather than relying on a series of generated summaries each time.
- Update message history building with a direct query to join the past chapters and choices.