### PR TITLE
Allow adventure retrieval

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -19,7 +19,7 @@ interface AppOptions {
 }
 
 function build(options: AppOptions): FastifyInstance {
-  const app = fastify({ logger: options.logger });
+  const app = fastify({ logger: options.logger, routerOptions: { ignoreTrailingSlash: true } });
 
   app.register(cors, { origin: options.corsOrigins });
 

--- a/src/routes/adventures/index.ts
+++ b/src/routes/adventures/index.ts
@@ -99,7 +99,7 @@ const plugin: FastifyPluginAsync<AdventuresRoutesOptions> = async (
                 items: {
                   type: 'object',
                   properties: {
-                    chapterNumber: { type: 'number' },
+                    number: { type: 'number' },
                     narrative: { type: 'string' },
                     choices: {
                       type: 'array',
@@ -130,8 +130,9 @@ const plugin: FastifyPluginAsync<AdventuresRoutesOptions> = async (
       if (!adventure) {
         return reply.code(404).send('This Adventure Is Lost');
       }
+      const chapters = await chaptersRepository.getByAdventureIdOrdered(adventure.id);
 
-      return { ...adventure, chapters: [] };
+      return { ...adventure, chapters };
     },
   );
 

--- a/src/routes/adventures/index.ts
+++ b/src/routes/adventures/index.ts
@@ -79,6 +79,63 @@ const plugin: FastifyPluginAsync<AdventuresRoutesOptions> = async (
   );
 
   fastify.post(
+    '/adventures/:id',
+    {
+      schema: {
+        params: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              setting: { type: 'string' },
+              chapters: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    chapterNumber: { type: 'number' },
+                    narrative: { type: 'string' },
+                    choices: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          id: { type: 'string' },
+                          action: { type: 'string' },
+                          chosen: { type: 'boolean' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          404: {
+            type: 'string',
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const { id } = request.params as { id: string };
+
+      const adventure = await adventuresRepository.getByIdWithSetting(id);
+      if (!adventure) {
+        return reply.code(404).send('This Adventure Is Lost');
+      }
+
+      return { id, chapters: [] };
+    },
+  );
+
+  fastify.post(
     '/adventures/:id/forth',
     {
       schema: {

--- a/src/routes/adventures/index.ts
+++ b/src/routes/adventures/index.ts
@@ -131,8 +131,17 @@ const plugin: FastifyPluginAsync<AdventuresRoutesOptions> = async (
         return reply.code(404).send('This Adventure Is Lost');
       }
       const chapters = await chaptersRepository.getByAdventureIdOrdered(adventure.id);
+      const chaptersChoices = await chapterChoicesRepository.getByAdventureId(adventure.id);
+      const chapterChoicesMap = new Map<string, ChapterChoice[]>(chapters.map((c) => [c.id, []]));
+      for (const choice of chaptersChoices) {
+        chapterChoicesMap.get(choice.chapter_id)?.push(choice);
+      }
+      const chaptersWithChoices = chapters.map((chapter) => ({
+        ...chapter,
+        choices: chapterChoicesMap.get(chapter.id),
+      }));
 
-      return { ...adventure, chapters };
+      return { ...adventure, chapters: chaptersWithChoices };
     },
   );
 

--- a/src/routes/adventures/index.ts
+++ b/src/routes/adventures/index.ts
@@ -78,7 +78,7 @@ const plugin: FastifyPluginAsync<AdventuresRoutesOptions> = async (
     },
   );
 
-  fastify.post(
+  fastify.get(
     '/adventures/:id',
     {
       schema: {
@@ -131,7 +131,7 @@ const plugin: FastifyPluginAsync<AdventuresRoutesOptions> = async (
         return reply.code(404).send('This Adventure Is Lost');
       }
 
-      return { id, chapters: [] };
+      return { ...adventure, chapters: [] };
     },
   );
 

--- a/tests/TestDbClient.ts
+++ b/tests/TestDbClient.ts
@@ -20,7 +20,7 @@ export default class TestDbClient {
   }
 
   async queryAdventureTypes() {
-    const result = await this.query('SELECT id, description FROM adventure_types;');
+    const result = await this.query('SELECT id, description, setting FROM adventure_types;');
     return result.rows;
   }
 

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -163,7 +163,38 @@ describe('Adventures Retrieval Tests', () => {
     expect(data.id).toEqual(adventure.id);
     expect(data).toHaveProperty('setting');
     expect(data).toHaveProperty('chapters');
-    expect(data.chapters.length).toBe(0);
+    const chapters = data.chapters;
+    expect(chapters.length).toBe(0);
+  });
+
+  test('It receives an adventure with a single chapter if just started', async () => {
+    onTestFinished(async () => {
+      await db.cleanupTables(['chapters', 'adventures']);
+    });
+    // We retrieve directly from DB
+    const adventureTypes = await db.queryAdventureTypes();
+    const adventureType = adventureTypes[0];
+
+    const adventure = await db.createAdventure(adventureType.id, true);
+    const chapter = await db.createChapter(adventure.id, 1, 'the initial chapter goes here');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/adventures/${adventure.id}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    const data = response.json();
+    console.log(data);
+    expect(data).toHaveProperty('id');
+    expect(data.id).toEqual(adventure.id);
+    expect(data).toHaveProperty('setting');
+    expect(data).toHaveProperty('chapters');
+    const chapters = data.chapters;
+    expect(chapters.length).toBe(1);
+    expect(chapters[0].number).toEqual(chapter.number);
+    expect(chapters[0].narrative).toEqual(chapter.narrative);
   });
 });
 

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -248,6 +248,10 @@ describe('Adventures Retrieval Tests', () => {
     expect(choices.length).toBe(2);
     const chosen = choices.find((choice: { chosen: boolean }) => choice.chosen);
     expect(chosen).toBeDefined();
+    expect(chosen).toHaveProperty('id');
+    expect(chosen.id).toEqual(chosenChapterChoice.id);
+    expect(chosen).toHaveProperty('action');
+    expect(chosen.action).toEqual(chosenChapterChoice.action);
   });
 
   test('It receives an adventure with a chapter with empty choices if it has concluded', async () => {

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -122,6 +122,26 @@ describe('Adventures Injection Tests', () => {
   });
 });
 
+describe('Adventures Retrieval Tests', () => {
+  const app = build(TEST_APP_OPTIONS);
+  const db = new TestDbClient(TEST_DATABASE_URL);
+  afterAll(() => {
+    app.close();
+    db.close();
+  });
+
+  test('It receives a 404 status if requesting an invalid adventure', async () => {
+    // DB is empty
+    const adventureId = '00000000-0000-0000-0000-000000000000';
+    const response = await app.inject({
+      method: 'GET',
+      url: `/adventures/${adventureId}`,
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+});
+
 describe('Adventures Gameplay Injection Tests', () => {
   const app = build({ ...TEST_APP_OPTIONS, maxAdventureChapters: 2 });
   const db = new TestDbClient(TEST_DATABASE_URL);

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test, afterAll, onTestFinished } from 'vitest';
 import build from '../src/app';
+import {
+  isOKResponse,
+  isJSONContent,
+  isExpectedAdventureResponse,
+  isExpectedChapterResponse,
+  isExpectedChapterChoiceResponse,
+} from './helpers';
 import TestDbClient from './TestDbClient';
 import mockGenerativeAIPlugin from './mockGenerativeAIService';
 import type { FastifyPluginAsync } from 'fastify';
@@ -30,8 +37,8 @@ describe('Aventure Types Injection Tests', async () => {
       url: '/adventure-types',
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    isOKResponse(response);
+    isJSONContent(response);
     expect(response.json()).toBeInstanceOf(Array);
   });
 
@@ -54,8 +61,8 @@ describe('Aventure Types Injection Tests', async () => {
       url: `/adventure-types/${requestedAdventureType.id}`,
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    isOKResponse(response);
+    isJSONContent(response);
     const received = response.json();
     expect(received).not.toHaveProperty('setting');
     expect(received.id).toEqual(requestedAdventureType.id);
@@ -96,8 +103,8 @@ describe('Adventures Injection Tests', () => {
       },
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    isOKResponse(response);
+    isJSONContent(response);
     expect(response.json()).toHaveProperty('adventure');
   });
 
@@ -156,13 +163,10 @@ describe('Adventures Retrieval Tests', () => {
       url: `/adventures/${adventure.id}`,
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    isOKResponse(response);
+    isJSONContent(response);
     const data = response.json();
-    expect(data).toHaveProperty('id');
-    expect(data.id).toEqual(adventure.id);
-    expect(data).toHaveProperty('setting');
-    expect(data).toHaveProperty('chapters');
+    isExpectedAdventureResponse(adventure, data);
     const chapters = data.chapters;
     expect(chapters.length).toBe(0);
   });
@@ -184,30 +188,18 @@ describe('Adventures Retrieval Tests', () => {
       url: `/adventures/${adventure.id}`,
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    isOKResponse(response);
+    isJSONContent(response);
     const data = response.json();
-    expect(data).toHaveProperty('id');
-    expect(data.id).toEqual(adventure.id);
-    expect(data).toHaveProperty('setting');
-    expect(data).toHaveProperty('chapters');
+    isExpectedAdventureResponse(adventure, data);
     const chapters = data.chapters;
     expect(chapters.length).toBe(1);
     const firstChapter = chapters[0];
-    expect(firstChapter).toHaveProperty('number');
-    expect(firstChapter.number).toEqual(chapter.number);
-    expect(firstChapter).toHaveProperty('narrative');
-    expect(firstChapter.narrative).toEqual(chapter.narrative);
-    expect(firstChapter).toHaveProperty('choices');
+    isExpectedChapterResponse(chapter, firstChapter);
     const choices = firstChapter.choices;
     expect(choices.length).toBe(1);
     const firstChoice = choices[0];
-    expect(firstChoice).toHaveProperty('id');
-    expect(firstChoice.id).toEqual(chapterChoice.id);
-    expect(firstChoice).toHaveProperty('action');
-    expect(firstChoice.action).toEqual(chapterChoice.action);
-    expect(firstChoice).toHaveProperty('chosen');
-    expect(firstChoice.chosen).toBe(false);
+    isExpectedChapterChoiceResponse(chapterChoice, firstChoice);
   });
 
   test('It receives an adventure with chosen chapter choices if underway', async () => {
@@ -229,29 +221,19 @@ describe('Adventures Retrieval Tests', () => {
       url: `/adventures/${adventure.id}`,
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    isOKResponse(response);
+    isJSONContent(response);
     const data = response.json();
-    expect(data).toHaveProperty('id');
-    expect(data.id).toEqual(adventure.id);
-    expect(data).toHaveProperty('setting');
-    expect(data).toHaveProperty('chapters');
+    isExpectedAdventureResponse(adventure, data);
     const chapters = data.chapters;
     expect(chapters.length).toBe(1);
     const firstChapter = chapters[0];
-    expect(firstChapter).toHaveProperty('number');
-    expect(firstChapter.number).toEqual(chapter.number);
-    expect(firstChapter).toHaveProperty('narrative');
-    expect(firstChapter.narrative).toEqual(chapter.narrative);
-    expect(firstChapter).toHaveProperty('choices');
+    isExpectedChapterResponse(chapter, firstChapter);
     const choices = firstChapter.choices;
     expect(choices.length).toBe(2);
     const chosen = choices.find((choice: { chosen: boolean }) => choice.chosen);
     expect(chosen).toBeDefined();
-    expect(chosen).toHaveProperty('id');
-    expect(chosen.id).toEqual(chosenChapterChoice.id);
-    expect(chosen).toHaveProperty('action');
-    expect(chosen.action).toEqual(chosenChapterChoice.action);
+    isExpectedChapterChoiceResponse(chosenChapterChoice, chosen);
   });
 
   test('It receives an adventure with a chapter with empty choices if it has concluded', async () => {
@@ -274,21 +256,14 @@ describe('Adventures Retrieval Tests', () => {
       url: `/adventures/${adventure.id}`,
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    isOKResponse(response);
+    isJSONContent(response);
     const data = response.json();
-    expect(data).toHaveProperty('id');
-    expect(data.id).toEqual(adventure.id);
-    expect(data).toHaveProperty('setting');
-    expect(data).toHaveProperty('chapters');
+    isExpectedAdventureResponse(adventure, data);
     const chapters = data.chapters;
     expect(chapters.length).toBe(1);
     const firstChapter = chapters[0];
-    expect(firstChapter).toHaveProperty('number');
-    expect(firstChapter.number).toEqual(chapter.number);
-    expect(firstChapter).toHaveProperty('narrative');
-    expect(firstChapter.narrative).toEqual(chapter.narrative);
-    expect(firstChapter).toHaveProperty('choices');
+    isExpectedChapterResponse(chapter, firstChapter);
     const choices = firstChapter.choices;
     expect(choices.length).toBe(0);
   });
@@ -350,8 +325,8 @@ describe('Adventures Gameplay Injection Tests', () => {
       payload: {},
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    isOKResponse(response);
+    isJSONContent(response);
     const data = response.json();
     expect(data).toHaveProperty('chapterNumber');
     expect(data).toHaveProperty('narrative');
@@ -427,8 +402,8 @@ describe('Adventures Gameplay Injection Tests', () => {
       },
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    isOKResponse(response);
+    isJSONContent(response);
     const data = response.json();
     expect(data).toHaveProperty('chapterNumber');
     expect(data).toHaveProperty('narrative');
@@ -475,8 +450,8 @@ describe('Adventures Gameplay Injection Tests', () => {
       },
     });
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    isOKResponse(response);
+    isJSONContent(response);
     const data = response.json();
     expect(data).toHaveProperty('chapterNumber');
     expect(data).toHaveProperty('narrative');

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -71,7 +71,7 @@ describe('Adventures Injection Tests', () => {
     db.close();
   });
 
-  test('It receives a 400 status if requesting without a valid adventure type', async () => {
+  test('It receives a 400 status if POSTing without a valid adventure type', async () => {
     const response = await app.inject({
       method: 'POST',
       url: '/adventures',

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -140,6 +140,31 @@ describe('Adventures Retrieval Tests', () => {
 
     expect(response.statusCode).toBe(404);
   });
+
+  test('It receives an adventure without chapters if just created', async () => {
+    onTestFinished(async () => {
+      await db.cleanupTables(['adventures']);
+    });
+    // We retrieve directly from DB
+    const adventureTypes = await db.queryAdventureTypes();
+    const adventureType = adventureTypes[0];
+
+    const adventure = await db.createAdventure(adventureType.id, true);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/adventures/${adventure.id}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+    const data = response.json();
+    expect(data).toHaveProperty('id');
+    expect(data.id).toEqual(adventure.id);
+    expect(data).toHaveProperty('setting');
+    expect(data).toHaveProperty('chapters');
+    expect(data.chapters.length).toBe(0);
+  });
 });
 
 describe('Adventures Gameplay Injection Tests', () => {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,45 @@
+import { Response } from 'light-my-request';
+import { expect } from 'vitest';
+
+const STATUS_OK = 200;
+
+export function isOKResponse(response: Response) {
+  expect(response.statusCode).toBe(STATUS_OK);
+}
+
+export function isJSONContent(response: Response) {
+  expect(response.headers['content-type']).toBe('application/json; charset=utf-8');
+}
+
+interface RetrievedAventure {
+  id: string;
+  setting: string;
+  chapters: Chapter[];
+}
+export function isExpectedAdventureResponse(want: RetrievedAventure, got: RetrievedAventure) {
+  expect(got).toHaveProperty('id', want.id);
+  expect(got).toHaveProperty('setting');
+  expect(got).toHaveProperty('chapters');
+}
+
+interface Chapter {
+  number: number;
+  narrative: string;
+  choices: unknown[];
+}
+export function isExpectedChapterResponse(want: Chapter, got: Chapter) {
+  expect(got).toHaveProperty('number', want.number);
+  expect(got).toHaveProperty('narrative', want.narrative);
+  expect(got).toHaveProperty('choices');
+}
+
+interface ChapterChoice {
+  id: string;
+  action: string;
+  chosen: boolean;
+}
+export function isExpectedChapterChoiceResponse(want: ChapterChoice, got: ChapterChoice) {
+  expect(got).toHaveProperty('id', want.id);
+  expect(got).toHaveProperty('action', want.action);
+  expect(got).toHaveProperty('chosen', want.chosen);
+}


### PR DESCRIPTION
An adventure can be requested, returning its current state including all chapters and choices. This allows users to resume adventures between sessions.